### PR TITLE
Reduce bundle size with SWC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ jspm_packages
 .node_repl_history
 
 .vscode
+
+# dist
+dist

--- a/.swcrc
+++ b/.swcrc
@@ -1,0 +1,40 @@
+{
+    // "$schema": "https://json.schemastore.org/swcrc",
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": false,
+            "dynamicImport": false,
+            "privateMethod": true,
+            "functionBind": true,
+            "exportDefaultFrom": false,
+            "exportNamespaceFrom": false,
+            "decorators": false,
+            "decoratorsBeforeExport": false,
+            "topLevelAwait": true,
+            "importMeta": false
+        },
+        "target": "es2018",
+        "loose": true,
+        "externalHelpers": false,
+        "minify": {
+            "compress": {
+                "defaults": true,
+                "dead_code": true
+            },
+            "mangle": {
+                "keepFnNames": false,
+                "keepClassNames": false
+            }
+        }
+    },
+    "module": {
+        "type": "commonjs",
+        // These are defaults.
+        "strict": true,
+        "strictMode": true,
+        "lazy": false,
+        "ignoreDynamic": true
+    },
+    "minify": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ node_js:
 
 script:
   - npx standard
+  - npm run build
   - npm run test

--- a/demos/basic-service-params.js
+++ b/demos/basic-service-params.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('../index')({})
+const service = require('../dist/index')({})
 
 service.get('/user/:id', (req, res) => {
   res.send('Hello user: ' + req.params.id)

--- a/demos/basic-service.js
+++ b/demos/basic-service.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 
 // the /v1/welcome route handler
 service.get('/v1/welcome', (req, res) => {

--- a/demos/before-send-async.js
+++ b/demos/before-send-async.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 
 const beforeSendAsyncHook = (req, res, sendArgs) => {
   sendArgs[0] += 'from pre-send handler!'

--- a/demos/body-parser.js
+++ b/demos/body-parser.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 const bodyParser = require('body-parser')
 
 // parse application/json

--- a/demos/error-handler.js
+++ b/demos/error-handler.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('../index')({
+const service = require('../dist/index')({
   errorHandler (err, req, res) {
     console.log(`Unexpected error: ${err.message}`)
     res.send(err)

--- a/demos/express-jwt.js
+++ b/demos/express-jwt.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 const jwt = require('express-jwt')
 
 service.use(

--- a/demos/get-routes.js
+++ b/demos/get-routes.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('../index')({})
+const service = require('../dist/index')({})
 
 // the /v1/welcome route handler
 service.get('/routes', (req, res) => {

--- a/demos/http2-service.js
+++ b/demos/http2-service.js
@@ -9,7 +9,7 @@ pem.createCertificate({
 }, (err, keys) => {
   if (err) console.error(err)
 
-  const service = require('./../index')({
+  const service = require('./../dist/index')({
     server: http2.createSecureServer({
       key: keys.serviceKey,
       cert: keys.certificate

--- a/demos/https-service.js
+++ b/demos/https-service.js
@@ -9,7 +9,7 @@ pem.createCertificate({
 }, (err, keys) => {
   if (err) console.error(err)
 
-  const service = require('./../index')({
+  const service = require('./../dist/index')({
     server: https.createServer({
       key: keys.serviceKey,
       cert: keys.certificate

--- a/demos/minimal-json.js
+++ b/demos/minimal-json.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 
 service.get('/hi', (req, res) => {
   res.send({

--- a/demos/minimal.js
+++ b/demos/minimal.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 
 service.get('/hi', (req, res) => {
   res.send('Hello World!')

--- a/demos/modular-nested-routers.js
+++ b/demos/modular-nested-routers.js
@@ -9,7 +9,7 @@ router1.get('/hi/:name', (req, res) => {
 })
 
 // restana service
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 service.use('/actions', router1)
 
 service.start()

--- a/demos/morgan.js
+++ b/demos/morgan.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 const morgan = require('morgan')
 
 service.use(morgan('tiny'))

--- a/demos/openapi/index.js
+++ b/demos/openapi/index.js
@@ -1,4 +1,4 @@
-const restana = require('../../index')
+const restana = require('../../dist/index')
 const path = require('path')
 
 const {

--- a/demos/query-parser.js
+++ b/demos/query-parser.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 service.get('/params', (req, res) => {
   res.send(req.query)
 })

--- a/demos/raw-body.js
+++ b/demos/raw-body.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 const rawbody = require('raw-body')
 
 service.use(async (req, res, next) => {

--- a/demos/response-time.js
+++ b/demos/response-time.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 
 // custom middleware to attach the X-Response-Time header to the response
 service.use(require('response-time')())

--- a/demos/restana-as-http-middleware.js
+++ b/demos/restana-as-http-middleware.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const http = require('http')
-const service = require('./../index')()
+const service = require('./../dist/index')()
 
 service.get('/hi', (req, res) => {
   res.send({

--- a/demos/route-middleware-express.js
+++ b/demos/route-middleware-express.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('../index')({})
+const service = require('../dist/index')({})
 
 // route without middlewares
 service.get('/hi/:name', async (req, res) => {

--- a/demos/socket.io-https-server.js
+++ b/demos/socket.io-https-server.js
@@ -9,7 +9,7 @@ pem.createCertificate({
 }, (err, keys) => {
   if (err) console.error(err)
 
-  const app = require('../index')({
+  const app = require('../dist/index')({
     server: http.createServer({
       key: keys.serviceKey,
       cert: keys.certificate

--- a/demos/static/app-cache.js
+++ b/demos/static/app-cache.js
@@ -3,7 +3,7 @@
 const files = require('serve-static')
 const path = require('path')
 
-const app = require('../../index')({
+const app = require('../../dist/index')({
   disableResponseEvent: true
 })
 app.use(require('http-cache-middleware')())

--- a/demos/static/app.js
+++ b/demos/static/app.js
@@ -4,7 +4,7 @@ const files = require('serve-static')
 const path = require('path')
 const serve = files(path.join(__dirname, 'src'))
 
-const app = require('../../index')({
+const app = require('../../dist/index')({
 })
 
 app.use(serve)

--- a/libs/index.js
+++ b/libs/index.js
@@ -6,10 +6,10 @@
  * @license MIT
  */
 
-const requestRouter = require('./libs/request-router')
+const requestRouter = require('./request-router')
 const exts = {
   request: {},
-  response: require('./libs/response-extensions')
+  response: require('./response-extensions')
 }
 
 module.exports = (options = {}) => {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "restana",
   "version": "4.9.8",
   "description": "Super fast and minimalist web framework for building REST micro-services.",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
+    "build": "npx rimraf ./dist && npm run build:cjs && npm run copy:types",
+    "build:cjs": "npx swc libs -d dist -D -s",
+    "copy:types": "cp index.d.ts ./dist/index.d.ts",
     "lint": "npx standard",
     "format": "npx standard --fix",
     "test": "cross-env PORT=3000 NODE_ENV=testing npx nyc --check-coverage --lines 95 node ./node_modules/mocha/bin/mocha specs/*.test.js",
@@ -32,15 +35,15 @@
   "files": [
     "LICENSE.md",
     "README.md",
-    "index.js",
-    "index.d.ts",
-    "libs/"
+    "dist/"
   ],
   "homepage": "https://github.com/jkyberneees/restana#readme",
   "dependencies": {
     "0http": "^3.5.2"
   },
   "devDependencies": {
+    "@swc/cli": "^0.1.62",
+    "@swc/core": "^1.3.73",
     "benchmark": "^2.1.4",
     "body-parser": "^1.20.1",
     "chai": "^4.3.7",
@@ -56,6 +59,7 @@
     "pem": "^1.14.6",
     "response-time": "^2.3.2",
     "restana-swagger-validator": "^0.1.4",
+    "rimraf": "^5.0.1",
     "serve-static": "^1.15.0",
     "socket.io": "^4.5.4",
     "socket.io-client": "^4.5.4",

--- a/performance/restana-minimal-cluster.js
+++ b/performance/restana-minimal-cluster.js
@@ -9,7 +9,7 @@ if (cluster.isMaster) {
     cluster.fork()
   }
 } else {
-  const service = require('./../index')({})
+  const service = require('./../dist/index')({})
 
   service.get('/hi', (req, res) => {
     res.send('Hello World!')

--- a/performance/restana-minimal-json.js
+++ b/performance/restana-minimal-json.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 
 service.get('/hi', (req, res) => {
   res.send({

--- a/performance/restana-minimal-low.js
+++ b/performance/restana-minimal-low.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const low = require('0http/lib/server/low')
-const service = require('../index')({
+const service = require('../dist/index')({
   prioRequestsProcessing: false,
   server: low()
 })

--- a/performance/restana-minimal-promise.js
+++ b/performance/restana-minimal-promise.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('../index')({})
+const service = require('../dist/index')({})
 service.get('/hi', (req, res) => {
   res.send(Promise.resolve('Hello World!'))
 })

--- a/performance/restana-minimal-slow.js
+++ b/performance/restana-minimal-slow.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('../index')({
+const service = require('../dist/index')({
   prioRequestsProcessing: false
 })
 

--- a/performance/restana-minimal.js
+++ b/performance/restana-minimal.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const service = require('./../index')({})
+const service = require('./../dist/index')({})
 service.get('/hi', (req, res) => {
   res.send('Hello World!')
 })

--- a/performance/swagger/restana-swagger-validator.js
+++ b/performance/swagger/restana-swagger-validator.js
@@ -1,4 +1,4 @@
-const restana = require('../../index')
+const restana = require('../../dist/index')
 const path = require('path')
 
 const {

--- a/specs/disable-response-event.test.js
+++ b/specs/disable-response-event.test.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect
 
 describe('Disable Response Event', () => {
   let server
-  const service = require('../index')({
+  const service = require('../dist/index')({
     disableResponseEvent: true
   })
   service.use((req, res, next) => {

--- a/specs/elastic-apm.test.js
+++ b/specs/elastic-apm.test.js
@@ -21,7 +21,7 @@ describe('Elastic APM Instrumentation', () => {
     pattern = null
   })
 
-  const service = require('../index')()
+  const service = require('../dist/index')()
   patch(service)
 
   service.get('/hello', (req, res) => {

--- a/specs/express-like-routes.test.js
+++ b/specs/express-like-routes.test.js
@@ -6,7 +6,7 @@ const expect = require('chai').expect
 
 describe('Express.js like routes handlers', () => {
   let server
-  const service = require('../index')()
+  const service = require('../dist/index')()
 
   const m1 = (req, res, next) => {
     next()

--- a/specs/hook-in-http-create-server.test.js
+++ b/specs/hook-in-http-create-server.test.js
@@ -6,7 +6,7 @@ const http = require('http')
 
 describe('http.createServer()', () => {
   let server
-  const service = require('../index')()
+  const service = require('../dist/index')()
 
   service.get('/string', (req, res) => {
     res.send('Hello World!')

--- a/specs/nested-router.test.js
+++ b/specs/nested-router.test.js
@@ -6,7 +6,7 @@ const request = require('supertest')
 
 describe('Buffer Responses', () => {
   let server
-  const service = require('../index')()
+  const service = require('../dist/index')()
   const nestedRouter = service.newRouter()
 
   nestedRouter.get('/hello', (req, res) => {

--- a/specs/newrelic-apm.test.js
+++ b/specs/newrelic-apm.test.js
@@ -21,7 +21,7 @@ describe('Elastic APM Instrumentation', () => {
     pattern = null
   })
 
-  const service = require('../index')()
+  const service = require('../dist/index')()
   patch(service)
 
   service.get('/hello', (req, res) => {

--- a/specs/routes-chaining.test.js
+++ b/specs/routes-chaining.test.js
@@ -5,7 +5,7 @@ const request = require('supertest')
 
 describe('Routes registration - method chaining', () => {
   let server
-  const service = require('../index')()
+  const service = require('../dist/index')()
   const op200 = (req, res) => {
     res.send()
   }

--- a/specs/send-headers.test.js
+++ b/specs/send-headers.test.js
@@ -6,7 +6,7 @@ const request = require('supertest')
 
 describe('Buffer Responses', () => {
   let server
-  const service = require('../index')()
+  const service = require('../dist/index')()
   const nestedRouter = service.newRouter()
 
   nestedRouter.get('/hello', (req, res) => {

--- a/specs/send.test.js
+++ b/specs/send.test.js
@@ -8,7 +8,7 @@ const stream = require('stream')
 
 describe('All Responses', () => {
   let server
-  const service = require('../index')()
+  const service = require('../dist/index')()
 
   service.get('/string', (req, res) => {
     res.send('Hello World!')

--- a/specs/slow-processing.test.js
+++ b/specs/slow-processing.test.js
@@ -5,7 +5,7 @@ const request = require('supertest')
 
 describe('Slow requests processing', () => {
   let server
-  const service = require('../index')({
+  const service = require('../dist/index')({
     prioRequestsProcessing: false
   })
   service.get('/hello', (req, res) => {

--- a/specs/smoke.test.js
+++ b/specs/smoke.test.js
@@ -7,7 +7,7 @@ const http = require('http')
 
 describe('Restana Web Framework - Smoke', () => {
   let server
-  const service = require('../index')({
+  const service = require('../dist/index')({
     server: http.createServer()
   })
 


### PR DESCRIPTION
Hello, I conducted some tests using SWC to reduce the file sizes and potentially improve the performance of this library.

Changes:
- Instead of publishing the "libs" folder, we now publish the "dist" folder.
- The TypeScript file is copied as soon as the build is finished, also to the "dist" folder.
- The examples and tests point to the "dist" folder and require the build to be done beforehand (npm run build).
- Currently, it is configured to export the maps (perhaps it's better to deactivate).

I would like to discuss the changes.